### PR TITLE
Remove 's.static_framework = true' from Fritz.podspec

### DIFF
--- a/Fritz.podspec
+++ b/Fritz.podspec
@@ -6,9 +6,6 @@ Pod::Spec.new do |s|
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.md' }
   s.author = { 'Jameson Toole' => 'info@fritz.ai' }
   s.source = { :git => 'https://github.com/fritzlabs/fritz-ai-ios-sdk.git', :tag => s.version.to_s }
-  s.requires_arc = true
-  s.static_framework = true
-
 
   s.requires_arc = true
 


### PR DESCRIPTION
With  `s.static_framework = true` there's no way to use Fritz as a dynamic framework. 
In order to use the `Fritz` as a dependency of another pod, that pod (any other pods higher in the dependency graph) has to be a static framework as well.

On the other hand, even after my changes, users can opt in to use static frameworks by adding `use_frameworks! :linkage => :static` to their `Podfile`.

A similar issue was present in Firebase SDK some time ago: https://github.com/firebase/firebase-ios-sdk/pull/6557

I've also removed duplicate `s.requires_arc = true` (duplicates are in lines 9 and 13).